### PR TITLE
Fixed raw path for Wikipedia dataset

### DIFF
--- a/dexml.ipynb
+++ b/dexml.ipynb
@@ -68,13 +68,75 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "metadata": {
         "id": "UrwvbQ-Ll08q"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: torch in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 1)) (2.3.0)\n",
+            "Requirement already satisfied: transformers in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 2)) (4.41.0)\n",
+            "Requirement already satisfied: wandb in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 3)) (0.17.0)\n",
+            "Requirement already satisfied: numpy in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 4)) (1.26.4)\n",
+            "Requirement already satisfied: scipy in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 5)) (1.13.0)\n",
+            "Requirement already satisfied: pandas in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 6)) (2.2.1)\n",
+            "Requirement already satisfied: tabulate in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 7)) (0.9.0)\n",
+            "Requirement already satisfied: tqdm in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 8)) (4.66.4)\n",
+            "Requirement already satisfied: sentence-transformers in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 9)) (2.7.0)\n",
+            "Requirement already satisfied: accelerate in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 10)) (0.30.1)\n",
+            "Requirement already satisfied: matplotlib in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from -r requirements.txt (line 11)) (3.8.4)\n",
+            "Requirement already satisfied: filelock in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from torch->-r requirements.txt (line 1)) (3.13.3)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from torch->-r requirements.txt (line 1)) (4.11.0)\n",
+            "Requirement already satisfied: sympy in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from torch->-r requirements.txt (line 1)) (1.12)\n",
+            "Requirement already satisfied: networkx in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from torch->-r requirements.txt (line 1)) (3.2.1)\n",
+            "Requirement already satisfied: jinja2 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from torch->-r requirements.txt (line 1)) (3.1.3)\n",
+            "Requirement already satisfied: fsspec in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from torch->-r requirements.txt (line 1)) (2024.3.1)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.23.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (0.23.0)\n",
+            "Requirement already satisfied: packaging>=20.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (24.0)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (6.0.1)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (2024.5.15)\n",
+            "Requirement already satisfied: requests in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (2.31.0)\n",
+            "Requirement already satisfied: tokenizers<0.20,>=0.19 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (0.19.1)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from transformers->-r requirements.txt (line 2)) (0.4.3)\n",
+            "Requirement already satisfied: click!=8.0.0,>=7.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (8.1.7)\n",
+            "Requirement already satisfied: docker-pycreds>=0.4.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (0.4.0)\n",
+            "Requirement already satisfied: gitpython!=3.1.29,>=1.0.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (3.1.43)\n",
+            "Requirement already satisfied: platformdirs in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (4.2.2)\n",
+            "Requirement already satisfied: protobuf!=4.21.0,<5,>=3.19.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (4.25.3)\n",
+            "Requirement already satisfied: psutil>=5.0.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (5.9.8)\n",
+            "Requirement already satisfied: sentry-sdk>=1.0.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (2.2.0)\n",
+            "Requirement already satisfied: setproctitle in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (1.3.3)\n",
+            "Requirement already satisfied: setuptools in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from wandb->-r requirements.txt (line 3)) (69.5.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from pandas->-r requirements.txt (line 6)) (2.9.0.post0)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from pandas->-r requirements.txt (line 6)) (2024.1)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from pandas->-r requirements.txt (line 6)) (2024.1)\n",
+            "Requirement already satisfied: scikit-learn in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from sentence-transformers->-r requirements.txt (line 9)) (1.4.1.post1)\n",
+            "Requirement already satisfied: Pillow in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from sentence-transformers->-r requirements.txt (line 9)) (10.3.0)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 11)) (1.2.1)\n",
+            "Requirement already satisfied: cycler>=0.10 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 11)) (0.12.1)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 11)) (4.51.0)\n",
+            "Requirement already satisfied: kiwisolver>=1.3.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 11)) (1.4.5)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from matplotlib->-r requirements.txt (line 11)) (3.1.2)\n",
+            "Requirement already satisfied: six>=1.4.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from docker-pycreds>=0.4.0->wandb->-r requirements.txt (line 3)) (1.16.0)\n",
+            "Requirement already satisfied: gitdb<5,>=4.0.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from gitpython!=3.1.29,>=1.0.0->wandb->-r requirements.txt (line 3)) (4.0.11)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from requests->transformers->-r requirements.txt (line 2)) (3.3.2)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from requests->transformers->-r requirements.txt (line 2)) (3.7)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from requests->transformers->-r requirements.txt (line 2)) (2.2.1)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from requests->transformers->-r requirements.txt (line 2)) (2024.2.2)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from jinja2->torch->-r requirements.txt (line 1)) (2.1.5)\n",
+            "Requirement already satisfied: joblib>=1.2.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from scikit-learn->sentence-transformers->-r requirements.txt (line 9)) (1.3.2)\n",
+            "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from scikit-learn->sentence-transformers->-r requirements.txt (line 9)) (3.4.0)\n",
+            "Requirement already satisfied: mpmath>=0.19 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from sympy->torch->-r requirements.txt (line 1)) (1.3.0)\n",
+            "Requirement already satisfied: smmap<6,>=3.0.1 in /Users/thekop/Repo/dissertation/.venv/lib/python3.12/site-packages (from gitdb<5,>=4.0.1->gitpython!=3.1.29,>=1.0.0->wandb->-r requirements.txt (line 3)) (5.0.1)\n",
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
       "source": [
-        "!pip install -r requirements.txt"
+        "%pip install -r requirements.txt"
       ]
     },
     {
@@ -86,20 +148,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 5,
       "metadata": {
         "id": "2xfaCpjRSjmK"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/home/nileshgupta_google_com/.conda/envs/xc/lib/python3.9/site-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-            "  from .autonotebook import tqdm as notebook_tqdm\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import sys, os, time, socket, yaml, wandb, logging, numpy as np\n",
         "import logging.config\n",
@@ -115,7 +168,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 120,
+      "execution_count": 6,
       "metadata": {
         "id": "T9WHXUy7Sz5R"
       },
@@ -136,7 +189,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 4,
       "metadata": {
         "id": "FbPF-VVhrCBJ"
       },
@@ -184,7 +237,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 25,
       "metadata": {},
       "outputs": [
         {
@@ -193,19 +246,19 @@
           "text": [
             "Downloading...\n",
             "From (original): https://drive.google.com/uc?id=1A_sL_mzpkmnr6g0DSZ0_xJTr4GN-rIfi\n",
-            "From (redirected): https://drive.google.com/uc?id=1A_sL_mzpkmnr6g0DSZ0_xJTr4GN-rIfi&confirm=t&uuid=270f3602-0ce6-40c5-bc39-6c0f457e4683\n",
-            "To: /mnt/disks/disk2/nileshgupta/DEXML/Datasets/Eurlex-4K.tar.gz\n",
-            "100%|████████████████████████████████████████| 157M/157M [00:04<00:00, 35.4MB/s]\n",
-            "./Eurlex-4K/\n",
-            "./Eurlex-4K/train_raw_texts.txt\n",
-            "./Eurlex-4K/X.tst.npz\n",
-            "./Eurlex-4K/X.tst.finetune.xlnet.npy\n",
-            "./Eurlex-4K/X.trn.npz\n",
-            "./Eurlex-4K/Y.trn.npz\n",
-            "./Eurlex-4K/Y.tst.npz\n",
-            "./Eurlex-4K/test_raw_texts.txt\n",
-            "./Eurlex-4K/X.trn.finetune.xlnet.npy\n",
-            "./Eurlex-4K/label_map.txt\n"
+            "From (redirected): https://drive.google.com/uc?id=1A_sL_mzpkmnr6g0DSZ0_xJTr4GN-rIfi&confirm=t&uuid=d57c53de-f627-40ea-96b9-cacb4b9dcc1b\n",
+            "To: /Users/thekop/Repo/dissertation/examples/DEXML/Datasets/Eurlex-4K.tar.gz\n",
+            "100%|████████████████████████████████████████| 157M/157M [00:14<00:00, 11.1MB/s]\n",
+            "x ./Eurlex-4K/\n",
+            "x ./Eurlex-4K/train_raw_texts.txt\n",
+            "x ./Eurlex-4K/X.tst.npz\n",
+            "x ./Eurlex-4K/X.tst.finetune.xlnet.npy\n",
+            "x ./Eurlex-4K/X.trn.npz\n",
+            "x ./Eurlex-4K/Y.trn.npz\n",
+            "x ./Eurlex-4K/Y.tst.npz\n",
+            "x ./Eurlex-4K/test_raw_texts.txt\n",
+            "x ./Eurlex-4K/X.trn.finetune.xlnet.npy\n",
+            "x ./Eurlex-4K/label_map.txt\n"
           ]
         }
       ],
@@ -217,7 +270,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 26,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -232,16 +285,16 @@
           "text": [
             "Read 15449 lines\n",
             "Dumping tokenized file at Datasets/EURLex-4K/raw/trn_X.bert-base-uncased_128.dat...\n",
-            "100%|█████████████████████████████████████████████| 1/1 [00:14<00:00, 14.29s/it]\n",
-            "Finished tokenize_dump_memmap in 14.2963 secs\n",
+            "100%|█████████████████████████████████████████████| 1/1 [00:11<00:00, 11.78s/it]\n",
+            "Finished tokenize_dump_memmap in 11.8053 secs\n",
             "Read 3865 lines\n",
             "Dumping tokenized file at Datasets/EURLex-4K/raw/tst_X.bert-base-uncased_128.dat...\n",
-            "100%|█████████████████████████████████████████████| 1/1 [00:03<00:00,  3.77s/it]\n",
-            "Finished tokenize_dump_memmap in 3.7781 secs\n",
+            "100%|█████████████████████████████████████████████| 1/1 [00:03<00:00,  3.82s/it]\n",
+            "Finished tokenize_dump_memmap in 3.8402 secs\n",
             "Read 3956 lines\n",
             "Dumping tokenized file at Datasets/EURLex-4K/raw/Y.bert-base-uncased_128.dat...\n",
-            "100%|█████████████████████████████████████████████| 1/1 [00:00<00:00,  7.25it/s]\n",
-            "Finished tokenize_dump_memmap in 0.1408 secs\n"
+            "100%|█████████████████████████████████████████████| 1/1 [00:01<00:00,  1.32s/it]\n",
+            "Finished tokenize_dump_memmap in 1.3373 secs\n"
           ]
         }
       ],
@@ -260,7 +313,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 27,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -275,9 +328,9 @@
           "text": [
             "Downloading...\n",
             "From (original): https://drive.google.com/uc?id=1WuquxCAg8D4lKr-eZXPv4nNw2S2lm7_E\n",
-            "From (redirected): https://drive.google.com/uc?id=1WuquxCAg8D4lKr-eZXPv4nNw2S2lm7_E&confirm=t&uuid=a28892c4-78c3-4762-a294-caec34754b78\n",
-            "To: /home/nilesh/work/DEXML/Datasets/LF-Amazon-131K.raw.zip\n",
-            "100%|████████████████████████████████████████| 245M/245M [00:02<00:00, 94.6MB/s]\n",
+            "From (redirected): https://drive.google.com/uc?id=1WuquxCAg8D4lKr-eZXPv4nNw2S2lm7_E&confirm=t&uuid=9756dcb4-7a68-41a1-8c4b-5d70fae79a7c\n",
+            "To: /Users/thekop/Repo/dissertation/examples/DEXML/Datasets/LF-Amazon-131K.raw.zip\n",
+            "100%|████████████████████████████████████████| 245M/245M [00:30<00:00, 7.96MB/s]\n",
             "Archive:  LF-Amazon-131K.raw.zip\n",
             "   creating: LF-Amazon-131K/\n",
             "  inflating: LF-Amazon-131K/lbl.json.gz  \n",
@@ -296,9 +349,68 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 28,
       "metadata": {},
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Reading raw dataset files...\n",
+            "Processing Y (label) files...\n",
+            "Processing X (input) files...\n",
+            "Tokenizing X (input) files...\n",
+            "Read 294805 lines\n",
+            "Dumping tokenized file at Datasets/LF-AmazonTitles-131K/raw/trn_X.bert-base-uncased_128.dat...\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 1/1 [00:05<00:00,  5.84s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Finished tokenize_dump_memmap in 6.0009 secs\n",
+            "Read 134835 lines\n",
+            "Dumping tokenized file at Datasets/LF-AmazonTitles-131K/raw/tst_X.bert-base-uncased_128.dat...\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 1/1 [00:02<00:00,  2.86s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Finished tokenize_dump_memmap in 2.9192 secs\n",
+            "Read 131073 lines\n",
+            "Dumping tokenized file at Datasets/LF-AmazonTitles-131K/raw/Y.bert-base-uncased_128.dat...\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 1/1 [00:02<00:00,  2.84s/it]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Finished tokenize_dump_memmap in 2.8952 secs\n"
+          ]
+        }
+      ],
       "source": [
         "process_lf_amazon_datasets('LF-AmazonTitles-131K')"
       ]
@@ -312,7 +424,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": 29,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -327,9 +439,9 @@
           "text": [
             "Downloading...\n",
             "From (original): https://drive.google.com/uc?id=12zH4mL2RX8iSvH0VCNnd3QxO4DzuHWnK\n",
-            "From (redirected): https://drive.google.com/uc?id=12zH4mL2RX8iSvH0VCNnd3QxO4DzuHWnK&confirm=t&uuid=391cf505-02cf-4591-8a96-37f829f9328e\n",
-            "To: /home/nilesh/work/DEXML/Datasets/LF-Amazon-1.3M.raw.zip\n",
-            "100%|████████████████████████████████████████| 890M/890M [00:13<00:00, 67.8MB/s]\n",
+            "From (redirected): https://drive.google.com/uc?id=12zH4mL2RX8iSvH0VCNnd3QxO4DzuHWnK&confirm=t&uuid=b7ae47aa-59e5-4602-9ea8-276065c636e9\n",
+            "To: /Users/thekop/Repo/dissertation/examples/DEXML/Datasets/LF-Amazon-1.3M.raw.zip\n",
+            "100%|████████████████████████████████████████| 890M/890M [01:38<00:00, 9.08MB/s]\n",
             "Archive:  LF-Amazon-1.3M.raw.zip\n",
             "   creating: LF-Amazon-1.3M/\n",
             "  inflating: LF-Amazon-1.3M/lbl.json.gz  \n",
@@ -348,61 +460,65 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 30,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
+            "Reading raw dataset files...\n",
+            "Processing Y (label) files...\n",
+            "Processing X (input) files...\n",
+            "Tokenizing X (input) files...\n",
             "Read 2248619 lines\n",
-            "Dumping tokenized file at Datasets/LF-AmazonTitles-1.3M/raw/trn_X.bert-base-uncased_32.dat...\n"
+            "Dumping tokenized file at Datasets/LF-AmazonTitles-1.3M/raw/trn_X.bert-base-uncased_128.dat...\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "100%|██████████| 5/5 [00:41<00:00,  8.34s/it]\n"
+            "100%|██████████| 5/5 [00:45<00:00,  9.11s/it]\n"
           ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Finished tokenize_dump_memmap in 41.7673 secs\n",
+            "Finished tokenize_dump_memmap in 46.0710 secs\n",
             "Read 970237 lines\n",
-            "Dumping tokenized file at Datasets/LF-AmazonTitles-1.3M/raw/tst_X.bert-base-uncased_32.dat...\n"
+            "Dumping tokenized file at Datasets/LF-AmazonTitles-1.3M/raw/tst_X.bert-base-uncased_128.dat...\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "100%|██████████| 2/2 [00:15<00:00,  7.57s/it]\n"
+            "100%|██████████| 2/2 [00:18<00:00,  9.36s/it]\n"
           ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Finished tokenize_dump_memmap in 15.1589 secs\n",
+            "Finished tokenize_dump_memmap in 19.1293 secs\n",
             "Read 1305265 lines\n",
-            "Dumping tokenized file at Datasets/LF-AmazonTitles-1.3M/raw/Y.bert-base-uncased_32.dat...\n"
+            "Dumping tokenized file at Datasets/LF-AmazonTitles-1.3M/raw/Y.bert-base-uncased_128.dat...\n"
           ]
         },
         {
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "100%|██████████| 3/3 [00:20<00:00,  6.89s/it]\n"
+            "100%|██████████| 3/3 [00:25<00:00,  8.65s/it]\n"
           ]
         },
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Finished tokenize_dump_memmap in 20.7157 secs\n"
+            "Finished tokenize_dump_memmap in 26.1658 secs\n"
           ]
         }
       ],
@@ -419,7 +535,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 33,
       "metadata": {},
       "outputs": [
         {
@@ -428,29 +544,29 @@
           "text": [
             "Downloading...\n",
             "From (original): https://drive.google.com/uc?id=10RBSf6nC9C38wUMwqWur2Yd8mCwtup5K\n",
-            "From (redirected): https://drive.google.com/uc?id=10RBSf6nC9C38wUMwqWur2Yd8mCwtup5K&confirm=t&uuid=73438cf6-d88c-40b7-805c-d28ab8576112\n",
-            "To: /mnt/disks/disk2/nileshgupta/DEXML/Datasets/LF-Wikipedia-500K/trn.raw.json.gz\n",
-            "100%|██████████████████████████████████████| 5.29G/5.29G [01:53<00:00, 46.7MB/s]\n",
+            "From (redirected): https://drive.google.com/uc?id=10RBSf6nC9C38wUMwqWur2Yd8mCwtup5K&confirm=t&uuid=50e16e32-fb16-45d7-881d-9f73075f6c63\n",
+            "To: /Users/thekop/Repo/dissertation/examples/DEXML/Datasets/LF-Wikipedia-500K/trn.raw.json.gz\n",
+            "100%|██████████████████████████████████████| 5.29G/5.29G [08:06<00:00, 10.9MB/s]\n",
             "Downloading...\n",
             "From (original): https://drive.google.com/uc?id=1pEyKXtkwHhinuRxmARhtwEQ39VIughDf\n",
-            "From (redirected): https://drive.google.com/uc?id=1pEyKXtkwHhinuRxmARhtwEQ39VIughDf&confirm=t&uuid=ffcdb80f-a49a-4e9e-812a-c0ef44a7ed0c\n",
-            "To: /mnt/disks/disk2/nileshgupta/DEXML/Datasets/LF-Wikipedia-500K/tst.raw.json.gz\n",
-            "100%|██████████████████████████████████████| 2.30G/2.30G [00:55<00:00, 41.1MB/s]\n",
+            "From (redirected): https://drive.google.com/uc?id=1pEyKXtkwHhinuRxmARhtwEQ39VIughDf&confirm=t&uuid=52e866b1-9338-4dc8-b598-3871eb9d7509\n",
+            "To: /Users/thekop/Repo/dissertation/examples/DEXML/Datasets/LF-Wikipedia-500K/tst.raw.json.gz\n",
+            "100%|██████████████████████████████████████| 2.30G/2.30G [03:29<00:00, 11.0MB/s]\n",
             "Downloading...\n",
             "From: https://drive.google.com/uc?id=1ZYTZPlnkPBCMcNqRRO-gNx8EPgtV-GL3\n",
-            "To: /mnt/disks/disk2/nileshgupta/DEXML/Datasets/LF-Wikipedia-500K/Yf.txt\n",
-            "100%|██████████████████████████████████████| 33.7M/33.7M [00:00<00:00, 38.0MB/s]\n"
+            "To: /Users/thekop/Repo/dissertation/examples/DEXML/Datasets/LF-Wikipedia-500K/Yf.txt\n",
+            "100%|██████████████████████████████████████| 33.7M/33.7M [00:02<00:00, 11.4MB/s]\n"
           ]
         }
       ],
       "source": [
         "!mkdir -p Datasets/LF-Wikipedia-500K\n",
-        "!cd Datasets/LF-Wikipedia-500K; gdown 10RBSf6nC9C38wUMwqWur2Yd8mCwtup5K; gdown 1pEyKXtkwHhinuRxmARhtwEQ39VIughDf; gdown 1ZYTZPlnkPBCMcNqRRO-gNx8EPgtV-GL3;"
+        "!cd Datasets/LF-Wikipedia-500K; gdown 10RBSf6nC9C38wUMwqWur2Yd8mCwtup5K; gdown 1pEyKXtkwHhinuRxmARhtwEQ39VIughDf; gdown 1ZYTZPlnkPBCMcNqRRO-gNx8EPgtV-GL3; mkdir -p raw"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 2,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -463,15 +579,15 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 7,
       "metadata": {},
       "outputs": [
         {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Processing Y (label) files...\n",
-            "Processing X (input) files...\n"
+            "Reading raw dataset files...\n",
+            "Processing Y (label) files...\n"
           ]
         }
       ],
@@ -492,7 +608,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 115,
+      "execution_count": 8,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -828,7 +944,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.9.13"
+      "version": "3.12.2"
     },
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
I discovered a bug in the Notebook, it doesn't create the raw directory currently for Wikipedia so fails when it tries to process the input files.
